### PR TITLE
Enable Compression

### DIFF
--- a/inc/helpers.ps1
+++ b/inc/helpers.ps1
@@ -17,7 +17,11 @@ function New-Backup( [string] $Type )
     $backupDirPath  = $Cfg.Paths.RemotePath
     $backupFileName = "$(Get-Date -Format 'yyyy-MM-ddTHH_mm_ss') $($Cfg.Source.Database)"
     
-    $params = @{ BackupAction = 'Database'; Verbose = $true }
+    $params = @{
+        BackupAction      = 'Database'
+        Verbose           = $true
+        CompressionOption = 'On'
+    }
     switch ($Type) 
     {
         'Full' { $backupFileName += '.full' }


### PR DESCRIPTION
Compression will greatly reduce backups size, restore is unaffected :
![image](https://github.com/user-attachments/assets/e99d43e4-0d37-442d-91c9-803ea2aeade7)
